### PR TITLE
When ROM bank 0 is selected it is converted to 1

### DIFF
--- a/minigbs.c
+++ b/minigbs.c
@@ -21,7 +21,7 @@ static uint8_t* banks[32];
 static struct GBSHeader h;
 static struct regs regs;
 
-static void bank_switch(int which){
+static void bank_switch(uint8_t which){
 	debug_msg("Bank switching to %d.", which);
 
 	if (which == 0){

--- a/minigbs.c
+++ b/minigbs.c
@@ -24,8 +24,11 @@ static struct regs regs;
 static void bank_switch(int which){
 	debug_msg("Bank switching to %d.", which);
 
-	// allowing bank switch to 0 seems to break some games
-	if(which > 0 && which < 32 && banks[which]){
+	if (which == 0){
+		which = 1;
+	}
+
+	if(which < 32 && banks[which]){
 		memcpy(mem + 0x4000, banks[which], 0x4000);
 		debug_msg("Bank switch success.");
 	}


### PR DESCRIPTION
Fixes [Grandia - Parallel Trippers](https://www.zophar.net/music/gameboy-gbs/grandia-parallel-trippers)

Found the explanation for bank switching here: https://b13rg.github.io/Gameboy-Bank-Switching/
Things looks a bit more complex but this did the trick.